### PR TITLE
fix: Add explicit type casting to resolve MSVC C4267 warning in Buffe…

### DIFF
--- a/src/Rendering/Core/Buffer.cpp
+++ b/src/Rendering/Core/Buffer.cpp
@@ -87,7 +87,7 @@ void VertexArray::AddVertexBuffer(const Buffer& vertexBuffer, const std::vector<
     }
     
     for (size_t i = 0; i < layout.size(); ++i) {
-        glVertexAttribPointer(m_vertexBufferIndex, layout[i], GL_FLOAT, GL_FALSE, stride, (void*)offset);
+        glVertexAttribPointer(m_vertexBufferIndex, static_cast<GLint>(layout[i]), GL_FLOAT, GL_FALSE, static_cast<GLsizei>(stride), (void*)offset);
         glEnableVertexAttribArray(m_vertexBufferIndex);
         offset += layout[i] * sizeof(float);
         m_vertexBufferIndex++;


### PR DESCRIPTION
…r.cpp

- Cast stride parameter to GLsizei in glVertexAttribPointer call
- Cast layout[i] to GLint for vertex attribute size parameter
- Resolves MSVC warning C4267 about size_t to GLsizei conversion
- Allows Windows build to complete successfully without treating warnings as errors