### PR TITLE
fix: Connect Window callbacks to InputManager and add composite pass …

### DIFF
--- a/src/Core/Engine.cpp
+++ b/src/Core/Engine.cpp
@@ -55,6 +55,25 @@ bool Engine::Initialize(const std::string& title, int /*width*/, int /*height*/)
     m_inputManager->Initialize();
     Logger::Info("Input manager initialized");
 
+    m_window->SetKeyCallback([this](int key, int scancode, int action, int mods) {
+        if (m_inputManager) {
+            m_inputManager->OnKeyEventThreaded(key, scancode, action, mods);
+        }
+    });
+    
+    m_window->SetMouseButtonCallback([this](int button, int action, int mods) {
+        if (m_inputManager) {
+            m_inputManager->OnMouseButtonEventThreaded(button, action, mods);
+        }
+    });
+    
+    m_window->SetMouseMoveCallback([this](double xpos, double ypos) {
+        if (m_inputManager) {
+            m_inputManager->OnMouseMoveEventThreaded(xpos, ypos);
+        }
+    });
+    Logger::Info("Window callbacks connected to input manager");
+
     m_renderer = Renderer::Create();
     if (!m_renderer || !m_renderer->Initialize()) {
         Logger::Error("Failed to initialize renderer");

--- a/src/Rendering/Pipelines/ForwardRenderPipeline.h
+++ b/src/Rendering/Pipelines/ForwardRenderPipeline.h
@@ -33,10 +33,13 @@ private:
     void RenderSpecialEffects(World* world);
     void SetupLighting();
     void SortTransparentObjects(World* world);
+    void CompositePass();
+    void RenderFullscreenQuad();
 
     std::shared_ptr<Shader> m_forwardShader;
     std::shared_ptr<Shader> m_transparentShader;
     std::shared_ptr<Shader> m_effectsShader;
+    std::shared_ptr<Shader> m_compositeShader;
     
     std::shared_ptr<FrameBuffer> m_framebuffer;
     std::shared_ptr<Texture> m_colorTexture;


### PR DESCRIPTION
…to ForwardRenderPipeline

- Connect Window GLFW callbacks to InputManager event handlers in Engine initialization
- Add CompositePass method to ForwardRenderPipeline to copy framebuffer content to screen
- Add RenderFullscreenQuad method and composite shader for screen display
- Fixes keyboard input being ignored and dark screen rendering issues on Windows