### PR TITLE
Fix Windows/MSVC compilation warnings (proper fix)

### DIFF
--- a/src/Audio/AudioClip.cpp
+++ b/src/Audio/AudioClip.cpp
@@ -1,8 +1,15 @@
 #include "AudioClip.h"
 #include "../Core/Logging/Logger.h"
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4244 4267 4456)
+#endif
 #define MINIMP3_IMPLEMENTATION
 #include "External/minimp3.h"
 #include "External/minimp3_ex.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 #ifdef OPENAL_AVAILABLE
 #include <AL/al.h>
 #endif

--- a/src/Core/Profiling/Profiler.h
+++ b/src/Core/Profiling/Profiler.h
@@ -143,8 +143,17 @@ private:
     std::string m_name;
 };
 
-#define PROFILE_SCOPE(name) ScopedProfiler _prof(name)
-#define PROFILE_FUNCTION() ScopedProfiler _prof(__FUNCTION__)
-#define PROFILE_GPU(name) ScopedGPUProfiler _gpuProf##__LINE__(name)
+// Helper macros for creating unique variable names
+#define GE_CONCAT_INNER(x,y) x##y
+#define GE_CONCAT(x,y) GE_CONCAT_INNER(x,y)
+#ifdef _MSC_VER
+#define GE_UNIQUE(base) GE_CONCAT(base, __COUNTER__)
+#else
+#define GE_UNIQUE(base) GE_CONCAT(base, __LINE__)
+#endif
+
+#define PROFILE_SCOPE(name) ScopedProfiler GE_UNIQUE(_prof)(name)
+#define PROFILE_FUNCTION() ScopedProfiler GE_UNIQUE(_prof)(__FUNCTION__)
+#define PROFILE_GPU(name) ScopedGPUProfiler GE_UNIQUE(_gpuProf)(name)
 
 }

--- a/src/Rendering/Core/FrameCapture.cpp
+++ b/src/Rendering/Core/FrameCapture.cpp
@@ -8,8 +8,15 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "../Core/stb_image_write.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif

--- a/src/Rendering/RenderManager.cpp
+++ b/src/Rendering/RenderManager.cpp
@@ -2,9 +2,6 @@
 #include "../Core/Logging/Logger.h"
 #include "../Core/Profiling/Profiler.h"
 #include "Core/GLDebug.h"
-#ifdef _WIN32
-#define _CRT_SECURE_NO_WARNINGS
-#endif
 #include "Core/stb_image_write.h"
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
- Fix PROFILE_GPU/PROFILE_SCOPE macros with proper two-step macro expansion using GE_CONCAT helpers
- Use __COUNTER__ on MSVC for truly unique variable names, __LINE__ on other compilers
- Wrap stb_image_write.h with pragma warning push/pop in FrameCapture.cpp to suppress C4996
- Wrap minimp3 headers with pragma warning push/pop in AudioClip.cpp to suppress C4244/C4267/C4456
- Remove incorrect _CRT_SECURE_NO_WARNINGS from RenderManager.cpp (now handled in FrameCapture.cpp)